### PR TITLE
Use Buildah bud to build images

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -1,0 +1,20 @@
+---
+name: Multi-arch builds
+
+on:
+  pull_request:
+
+jobs:
+  apply-suggestions-commits:
+    name: Check the multi-arch builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Build the multi-arch images
+        run: make multiarch-images

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,7 @@ linters:
     - gocritic
     - gocyclo
     - goerr113
-    # - godot TODO
+    - godot
     # - godox #  Let's not forbid inline TODOs, FIXMEs et al
     - gofmt
     - gofumpt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,7 +61,7 @@ linters:
     - gomoddirectives
     # - gomodguard # We don't block any modules
     # - goprintffuncname # This doesn't seem useful at all
-    # - gosec TODO
+    - gosec
     - gosimple
     - govet
     # - ifshort # This is a style preference and doesn't seem compelling

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,7 +85,7 @@ linters:
     - prealloc
     - predeclared
     - promlinter
-    # - revive TODO
+    - revive
     # - rowserrcheck # We don't use SQL
     # - scopelint # Deprecated since v1.39.0
     # - sqlclosecheck # We don't use SQL

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters:
     # - forcetypeassert # There are many unchecked type assertions that would be the result of a programming error so the
     #                     reasonable recourse would be to panic anyway if checked so this doesn't seem useful
     # - funlen # gocyclo is enabled which is generally a better metric than simply LOC.
-    # - gci TODO
+    - gci
     # - gochecknoglobals # We don't want to forbid global variable constants
     # - gochecknoinits # We use init functions for valid reasons
     - gocognit

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,144 @@
+---
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - ifElseChain
+      - unnamedResult
+  gocyclo:
+    min-complexity: 15
+  govet:
+    enable:
+      - fieldalignment
+  lll:
+    line-length: 140
+  wsl:
+    # Separating explicit var declarations by blank lines seems excessive.
+    allow-cuddle-declarations: true
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    # - cyclop # This is equivalent to gocyclo
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - errorlint
+    - errname
+    # - exhaustive TODO
+    # - exhaustivestruct # Not recommended for general use - meant to be used only for special cases
+    - exportloopref
+    # - forbidigo # We don't forbid any statements
+    # - forcetypeassert # There are many unchecked type assertions that would be the result of a programming error so the
+    #                     reasonable recourse would be to panic anyway if checked so this doesn't seem useful
+    # - funlen # gocyclo is enabled which is generally a better metric than simply LOC.
+    # - gci TODO
+    # - gochecknoglobals # We don't want to forbid global variable constants
+    # - gochecknoinits # We use init functions for valid reasons
+    - gocognit
+    - goconst
+    # - gocritic TODO
+    - gocyclo
+    - goerr113
+    # - godot TODO
+    # - godox #  Let's not forbid inline TODOs, FIXMEs et al
+    # - gofmt TODO
+    # - gofumpt TODO
+    # - goheader # We do license header linting another way
+    # - goimports TODO
+    # - golint # Deprecated since v1.41.0
+    # - gomnd # It doesn't seem useful in general to enforce constants for all numeric values
+    - gomoddirectives
+    # - gomodguard # We don't block any modules
+    # - goprintffuncname # This doesn't seem useful at all
+    # - gosec TODO
+    - gosimple
+    - govet
+    # - ifshort # This is a style preference and doesn't seem compelling
+    - importas
+    - ineffassign
+    # - ireturn # The argument to always "Return Concrete Types" doesn't seem compelling. It is perfectly valid to return
+    #             an interface to avoid exposing the entire underlying struct
+    # - interfacer # Deprecated since v1.38.0
+    # - lll TODO
+    - makezero
+    # - maligned # Deprecated since v1.38.0
+    - misspell
+    - nakedret
+    # - nestif # This calculates cognitive complexity but we're doing that elsewhere
+    - nilerr
+    # - nilnil TODO
+    # - nlreturn # This is reasonable with a block-size of 2 but setting it above isn't honored
+    # - noctx # We don't send HTTP requests
+    - nolintlint
+    # - paralleltest # Not relevant for Ginkgo UTs
+    - prealloc
+    - predeclared
+    - promlinter
+    # - revive TODO
+    # - rowserrcheck # We don't use SQL
+    # - scopelint # Deprecated since v1.39.0
+    # - sqlclosecheck # We don't use SQL
+    - staticcheck
+    - structcheck
+    # - stylecheck TODO
+    # - tagliatelle # Inconsistent with stylecheck and not as good
+    # - tenv # Not relevant for our Ginkgo UTs
+    # - testpackage TODO
+    # - thelper # Not relevant for our Ginkgo UTs
+    # - tparallel # Not relevant for our Ginkgo UTs
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    # - varnamelen # It doesn't seem necessary to enforce a minimum variable name length
+    - wastedassign
+    # - whitespace TODO
+    - wrapcheck
+    # - wsl TODO
+issues:
+  exclude-rules:
+    # Allow dot-imports for Gomega BDD directives per idiomatic Gomega
+    - linters:
+        - revive
+        - stylecheck
+      text: "dot imports"
+      source: "gomega"
+
+    # Allow dot-imports for Ginkgo BDD directives per idiomatic Ginkgo
+    - linters:
+        - revive
+        - stylecheck
+      text: "dot imports"
+      source: "ginkgo"
+
+    # Ignore pointer bytes in struct alignment tests (this is a very
+    # minor optimisation)
+    - linters:
+        - govet
+      text: "pointer bytes could be"
+
+    # Full text of the error is "do not define dynamic errors, use wrapped static errors instead". See
+    # https://github.com/Djarvur/go-err113/issues/10 for an interesting discussion of this error. While there are cases
+    # where wrapped sentinel errors are useful, it seems a bit pedantic to force that pattern in all cases.
+    - linters:
+        - goerr113
+      text: "do not define dynamic errors"
+
+    # Ignore certain linters for test files
+    - path: _test\.go|test/|fake/
+      linters:
+        - gochecknoinits
+        - goerr113
+        - wrapcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters:
     - errcheck
     - errorlint
     - errname
-    # - exhaustive TODO
+    - exhaustive
     # - exhaustivestruct # Not recommended for general use - meant to be used only for special cases
     - exportloopref
     # - forbidigo # We don't forbid any statements

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,10 +52,10 @@ linters:
     - goerr113
     # - godot TODO
     # - godox #  Let's not forbid inline TODOs, FIXMEs et al
-    # - gofmt TODO
-    # - gofumpt TODO
+    - gofmt
+    - gofumpt
     # - goheader # We do license header linting another way
-    # - goimports TODO
+    - goimports
     # - golint # Deprecated since v1.41.0
     # - gomnd # It doesn't seem useful in general to enforce constants for all numeric values
     - gomoddirectives

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,7 +47,7 @@ linters:
     # - gochecknoinits # We use init functions for valid reasons
     - gocognit
     - goconst
-    # - gocritic TODO
+    - gocritic
     - gocyclo
     - goerr113
     # - godot TODO

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -104,9 +104,9 @@ linters:
     - varcheck
     # - varnamelen # It doesn't seem necessary to enforce a minimum variable name length
     - wastedassign
-    # - whitespace TODO
+    - whitespace
     - wrapcheck
-    # - wsl TODO
+    - wsl
 issues:
   exclude-rules:
     # Allow dot-imports for Gomega BDD directives per idiomatic Gomega

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,7 +70,7 @@ linters:
     # - ireturn # The argument to always "Return Concrete Types" doesn't seem compelling. It is perfectly valid to return
     #             an interface to avoid exposing the entire underlying struct
     # - interfacer # Deprecated since v1.38.0
-    # - lll TODO
+    - lll
     - makezero
     # - maligned # Deprecated since v1.38.0
     - misspell

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,7 +94,7 @@ linters:
     - stylecheck
     # - tagliatelle # Inconsistent with stylecheck and not as good
     # - tenv # Not relevant for our Ginkgo UTs
-    # - testpackage TODO
+    - testpackage
     # - thelper # Not relevant for our Ginkgo UTs
     # - tparallel # Not relevant for our Ginkgo UTs
     - typecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,7 +91,7 @@ linters:
     # - sqlclosecheck # We don't use SQL
     - staticcheck
     - structcheck
-    # - stylecheck TODO
+    - stylecheck
     # - tagliatelle # Inconsistent with stylecheck and not as good
     # - tenv # Not relevant for our Ginkgo UTs
     # - testpackage TODO

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,7 +77,7 @@ linters:
     - nakedret
     # - nestif # This calculates cognitive complexity but we're doing that elsewhere
     - nilerr
-    # - nilnil TODO
+    - nilnil
     # - nlreturn # This is reasonable with a block-size of 2 but setting it above isn't honored
     # - noctx # We don't send HTTP requests
     - nolintlint

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 BASE_BRANCH ?= devel
 OCM_BASE_BRANCH ?= main
 IMAGES ?= shipyard-dapper-base shipyard-linting nettest
-NON_DAPPER_GOALS += images
+MULTIARCH_IMAGES ?= nettest
+PLATFORMS ?= linux/amd64,linux/arm64
+NON_DAPPER_GOALS += images multiarch-images
 SHELLCHECK_ARGS := scripts/shared/lib/*
 FOCUS ?=
 SKIP ?=

--- a/Makefile.images
+++ b/Makefile.images
@@ -27,8 +27,14 @@ package/.image.%: $$(call docker_deps,package/Dockerfile.$$*) $$(call force_imag
 # Default target to build images based on IMAGES variable
 images: $(foreach image,$(IMAGES),package/.image.$(image))
 
+# [multiarch-images] builds all multi-arch container images
+# Default target to build images based on the MULTIARCH_IMAGES variable
+# Default platforms based on the PLATFORMS variable
+multiarch-images: IMAGES_ARGS += --platform $(PLATFORMS)
+multiarch-images: $(foreach image,$(MULTIARCH_IMAGES),package/.image.$(image))
+
 # [release-images] uploads the project's images to a public repository
-release-images:
+release-images: multiarch-images images
 	$(SCRIPTS_DIR)/release_images.sh $(IMAGES) $(RELEASE_ARGS)
 
-.PHONY: images release-images
+.PHONY: images multiarch-images release-images

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -90,10 +90,10 @@ export GO
 # Shipyard provided targets
 
 ##### CLEANING TARGETS #####
-.PHONY: clean clean-clusters clean-generated clean-buildx
+.PHONY: clean clean-clusters clean-generated
 
 # [clean] cleans everything (running clusters, generated files ...)
-clean: clean-clusters clean-generated clean-buildx
+clean: clean-clusters clean-generated
 
 # [clean-generated] removes files we generated
 clean-generated:
@@ -103,12 +103,6 @@ clean-generated:
 clean-clusters:
 	$(SCRIPTS_DIR)/cleanup.sh $(CLEANUP_ARGS)
 cleanup: clean-clusters
-
-# [clean-buildx] removes the buildx builder, if any
-clean-buildx:
-	docker buildx version > /dev/null 2>&1 && \
-	docker buildx use buildx_builder > /dev/null 2>&1 && \
-	docker buildx rm
 
 ##### DEPLOYMENT& TESTING TARGETS #####
 .PHONY: clusters preload-images deploy e2e upgrade-e2e deploy-latest

--- a/gh-actions/release-images/action.yaml
+++ b/gh-actions/release-images/action.yaml
@@ -14,15 +14,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - shell: bash
-      env:
-        IMAGES_ARGS: --nocache ${{ inputs.image_args }}
-      run: |
-        echo "::group::Build new images"
-        make images
-        echo "::endgroup::"
-
-    - name: Release newly built images
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+    - name: Build and release images
       shell: bash
       env:
         QUAY_USERNAME: ${{ inputs.username }}

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -13,6 +13,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # Requirements:
 # Component        | Usage
 # -------------------------------------------------------------
+# buildah          | container image construction
 # curl             | download other tools
 # findutils        | make unit (find unit test dirs)
 # gcc              | needed by `go test -race` (https://github.com/golang/go/issues/27089)
@@ -28,7 +29,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # kubectl          | e2e tests (in kubernetes-client)
 # make             | OLM installation
 # markdownlint     | Markdown linting
-# moby-engine      | Dapper (Docker)
+# moby-engine      | Docker (for Dapper)
 # npm              | Required for installing markdownlint
 # qemu-user-static | Emulation (for multiarch builds)
 # ShellCheck       | shell script linting
@@ -39,7 +40,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
-                   gcc git-core curl moby-engine make golang kubernetes-client \
+                   gcc git-core curl buildah moby-engine make golang kubernetes-client \
                    findutils upx jq ShellCheck npm gitlint yamllint \
                    qemu-user-static python3-pip && \
     npm install -g markdownlint-cli && \
@@ -55,7 +56,6 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 ENV LINT_VERSION=v1.43.0 \
     HELM_VERSION=v3.7.1 \
     KIND_VERSION=v0.11.1 \
-    BUILDX_VERSION=v0.7.1 \
     GH_VERSION=2.2.0 \
     YQ_VERSION=4.14.1
 
@@ -66,9 +66,6 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
     curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
     GOFLAGS="" go get -v github.com/mikefarah/yq/v4@v${YQ_VERSION} && \
-    mkdir -p ~/.docker/cli-plugins && \
-    curl -L "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${ARCH}" -o ~/.docker/cli-plugins/docker-buildx && \
-    chmod 755 ~/.docker/cli-plugins/docker-buildx && \
     curl -L https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz | tar xzf - && \
     mv gh_${GH_VERSION}_linux_${ARCH}/bin/gh /go/bin/ && \
     rm -rf gh_${GH_VERSION}_linux_${ARCH} && \

--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -2,15 +2,13 @@
 
 ## Process command line flags ##
 
-default_platform=linux/amd64
 source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'tag' "${DEV_VERSION}" "Tag to set for the local image"
 DEFINE_string 'repo' 'quay.io/submariner' "Quay.io repo to use for the image"
 DEFINE_string 'image' '' "Image name to build" 'i'
 DEFINE_string 'dockerfile' '' "Dockerfile to build from" 'f'
 DEFINE_string 'buildargs' '' "Build arguments to pass to 'docker build'"
-DEFINE_boolean 'cache' true "Use cached layers from latest image"
-DEFINE_string 'platform' "${default_platform}" 'Platforms to target'
+DEFINE_string 'platform' '' 'Platforms to target'
 DEFINE_string 'hash' '' "File to write the hash to" 'h'
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
@@ -22,7 +20,6 @@ dockerfile="${FLAGS_dockerfile}"
 buildargs="${FLAGS_buildargs}"
 platform="${FLAGS_platform}"
 hashfile="${FLAGS_hash}"
-[[ "${FLAGS_cache}" = "${FLAGS_TRUE}" ]] && cache=true || cache=false
 
 [[ -n "${image}" ]] || { echo "The image to build must be specified!"; exit 1; }
 [[ -n "${dockerfile}" ]] || { echo "The dockerfile to build from must be specified!"; exit 1; }
@@ -34,30 +31,41 @@ set -e
 local_image=${repo}/${image}:${tag}
 cache_image=${repo}/${image}:${CUTTING_EDGE}
 
-# When using cache pull latest image from the repo, so that it's layers may be reused.
-cache_flag=''
-if [[ "$cache" = true ]]; then
-    cache_flag="--cache-from ${cache_image}"
-    if [[ -z "$(docker image ls -q ${cache_image})" ]]; then
-        docker pull ${cache_image} || :
-    fi
-    for parent in $(grep FROM ${dockerfile} | cut -f2 -d' ' | grep -v scratch); do
-        cache_flag+=" --cache-from ${parent}"
-        docker pull ${parent} || :
-    done
-fi
+# We always use manifest builds
+buildah manifest rm "${image}" || :
+buildah manifest create "${image}" || :
 
-# Rebuild the image to update any changed layers and tag it back so it will be used.
-buildargs_flag="--build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_BRANCH=${BASE_BRANCH}"
+buildargs_flag="--build-arg BASE_BRANCH=${BASE_BRANCH}"
 [[ -z "${buildargs}" ]] || buildargs_flag="${buildargs_flag} --build-arg ${buildargs}"
-if docker buildx version > /dev/null 2>&1; then
-    docker buildx use buildx_builder || docker buildx create --name buildx_builder --use
-    docker buildx build --load -t ${local_image} ${cache_flag} -f ${dockerfile} --iidfile "${hashfile}" --platform ${platform} ${buildargs_flag} .
+
+# Default to linux/amd64 (for CI); Buildah platforms match Go OS/arch
+if command -v "${GO:-go}" >/dev/null; then
+    default_platform="$(${GO:-go} env GOOS)/$(${GO:-go} env GOARCH)"
 else
-    # Fall back to plain BuildKit
-    if [[ "${platform}" != "${default_platform}" ]]; then
-        echo "WARNING: buildx isn't available, cross-arch builds won't work as expected"
-    fi
-    DOCKER_BUILDKIT=1 docker build -t ${local_image} ${cache_flag} -f ${dockerfile} --iidfile "${hashfile}" ${buildargs_flag} .
+    echo Unable to determine default container image platform, assuming linux/amd64
+    default_platform=linux/amd64
 fi
-docker tag ${local_image} ${cache_image}
+[[ -n "$platform" ]] || platform="$default_platform"
+
+OIFS="$IFS"; IFS=,; platforms=($platform); IFS="$OIFS"
+for p in "${platforms[@]}"; do
+    # We need to manually specify TARGETPLATFORM
+    # See https://github.com/containers/buildah/issues/1368 (closed but not actually fixed)
+    buildah bud --tag "${local_image}" \
+                --manifest "${image}" \
+                --file "${dockerfile}" \
+                --iidfile "${hashfile}.${p/\//-}" \
+                --platform "${p}" \
+                ${buildargs_flag} \
+                --build-arg TARGETPLATFORM=${p} \
+                .
+    
+    # Make images matching the local platform available to Docker, and link their hashfile
+    if [ "$p" = "$default_platform" ]; then
+        ln -sf "${hashfile}.${p/\//-}" "${hashfile}"
+        buildah push ${local_image} docker-daemon:${local_image} || :
+        buildah push ${local_image} docker-daemon:${cache_image} || :
+    fi
+done
+
+buildah tag ${local_image} ${cache_image}

--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -56,6 +56,9 @@ function post_analyze() {
     print_section "* Output of 'subctl show all' in $cluster *"
     subctl show all
 
+    print_section "* Output of 'subctl diagnose all' in $cluster *"
+    subctl diagnose all
+
     return 0
 }
 

--- a/scripts/shared/release_images.sh
+++ b/scripts/shared/release_images.sh
@@ -23,15 +23,15 @@ source ${SCRIPTS_DIR}/lib/debug_functions
 
 function release_image() {
     local image=$1
+    local manifest=${image##*/}
 
     for target_tag in $VERSION $release_tag; do
         local target_image="${image}:${target_tag#v}"
-        docker tag ${image}:${DEV_VERSION} ${target_image}
-        docker push ${target_image}
+	    buildah manifest push --all ${manifest} docker://${target_image}
     done
 }
 
-echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+echo "$QUAY_PASSWORD" | buildah login -u "$QUAY_USERNAME" --password-stdin quay.io
 for image in "$@"; do
     release_image ${repo}/${image}
 done

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -44,7 +44,6 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 
 	framework.BeforeSuite()
 	return nil
-
 }, func(data []byte) {
 	// Run on all Ginkgo nodes
 })
@@ -56,7 +55,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 var _ = ginkgo.SynchronizedAfterSuite(func() {
 	// Run on all Ginkgo nodes
 
-	//framework.Logf("Running AfterSuite actions on all node")
+	// framework.Logf("Running AfterSuite actions on all node")
 	framework.RunCleanupActions()
 }, func() {
 	// Run only Ginkgo on node 1

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -15,15 +15,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package e2e
+package e2e_test
 
 import (
 	"testing"
 
+	"github.com/submariner-io/shipyard/test/e2e"
 	_ "github.com/submariner-io/shipyard/test/e2e/dataplane"
 	_ "github.com/submariner-io/shipyard/test/e2e/example"
 )
 
 func TestE2E(t *testing.T) {
-	RunE2ETests(t)
+	e2e.RunE2ETests(t)
 }

--- a/test/e2e/example/example.go
+++ b/test/e2e/example/example.go
@@ -54,11 +54,15 @@ func testListingNodes() {
 
 func testListingNodesFromCluster(cs *kubernetes.Clientset) {
 	nc := cs.CoreV1().Nodes()
+
 	By("Requesting node list from API")
+
 	nodes, err := nc.List(context.TODO(), metav1.ListOptions{})
 	Expect(err).NotTo(HaveOccurred())
+
 	By("Checking that we had more than 0 nodes on the response")
 	Expect(len(nodes.Items)).ToNot(BeZero())
+
 	for i := range nodes.Items {
 		inIP, err := getIP(v1.NodeInternalIP, &nodes.Items[i])
 		Expect(err).NotTo(HaveOccurred())
@@ -98,12 +102,16 @@ func testCreatingAPod(f *framework.Framework) {
 
 func testCreatingAPodInCluster(cs *kubernetes.Clientset, f *framework.Framework) {
 	pc := cs.CoreV1().Pods(f.Namespace)
+
 	By("Creating a bunch of pods")
+
 	for i := 0; i < 3; i++ {
 		_, err := pc.Create(context.TODO(), &testPod, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	}
+
 	By("Waiting for the example-pod(s) to be scheduled and running")
+
 	err := wait.PollImmediate(10*time.Second, 1*time.Minute, func() (bool, error) {
 		pods, err := pc.List(context.TODO(), metav1.ListOptions{LabelSelector: "example-pod"})
 		if err != nil {
@@ -126,9 +134,12 @@ func testCreatingAPodInCluster(cs *kubernetes.Clientset, f *framework.Framework)
 		return true, nil // all pods are running
 	})
 	Expect(err).NotTo(HaveOccurred())
+
 	By("Collecting pod ClusterIPs just for fun")
+
 	pods, err := pc.List(context.TODO(), metav1.ListOptions{LabelSelector: "example-pod"})
 	Expect(err).NotTo(HaveOccurred())
+
 	for i := range pods.Items {
 		framework.Logf("Detected pod with IP: %v", pods.Items[i].Status.PodIP)
 	}
@@ -140,5 +151,6 @@ func getIP(iptype v1.NodeAddressType, node *v1.Node) (string, error) {
 			return addr.Address, nil
 		}
 	}
+
 	return "", fmt.Errorf("did not find %s on Node", iptype)
 }

--- a/test/e2e/example/example.go
+++ b/test/e2e/example/example.go
@@ -66,31 +66,29 @@ func testListingNodesFromCluster(cs *kubernetes.Clientset) {
 	}
 }
 
-var (
-	testPod = v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "example-pod",
-			Labels: map[string]string{
-				"example-pod": "",
-			},
+var testPod = v1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		GenerateName: "example-pod",
+		Labels: map[string]string{
+			"example-pod": "",
 		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:    "example-pod",
-					Image:   "busybox",
-					Command: []string{"sh", "-c", "echo Hello Kubernetes, I am at $POD_IP! && sleep 3600"},
-					Env: []v1.EnvVar{
-						{
-							Name:      "POD_IP",
-							ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIP"}},
-						},
+	},
+	Spec: v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:    "example-pod",
+				Image:   "busybox",
+				Command: []string{"sh", "-c", "echo Hello Kubernetes, I am at $POD_IP! && sleep 3600"},
+				Env: []v1.EnvVar{
+					{
+						Name:      "POD_IP",
+						ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIP"}},
 					},
 				},
 			},
 		},
-	}
-)
+	},
+}
 
 func testCreatingAPod(f *framework.Framework) {
 	for _, cs := range framework.KubeClients {

--- a/test/e2e/example/example.go
+++ b/test/e2e/example/example.go
@@ -59,8 +59,8 @@ func testListingNodesFromCluster(cs *kubernetes.Clientset) {
 	Expect(err).NotTo(HaveOccurred())
 	By("Checking that we had more than 0 nodes on the response")
 	Expect(len(nodes.Items)).ToNot(BeZero())
-	for _, node := range nodes.Items {
-		inIP, err := getIP(v1.NodeInternalIP, &node)
+	for i := range nodes.Items {
+		inIP, err := getIP(v1.NodeInternalIP, &nodes.Items[i])
 		Expect(err).NotTo(HaveOccurred())
 		framework.Logf("Detected node with IP: %v", inIP)
 	}
@@ -115,9 +115,9 @@ func testCreatingAPodInCluster(cs *kubernetes.Clientset, f *framework.Framework)
 		}
 
 		// check all pods are running
-		for _, pod := range pods.Items {
-			if pod.Status.Phase != v1.PodRunning {
-				if pod.Status.Phase != v1.PodPending {
+		for i := range pods.Items {
+			if pods.Items[i].Status.Phase != v1.PodRunning {
+				if pods.Items[i].Status.Phase != v1.PodPending {
 					return false, fmt.Errorf("expected pod to be in phase \"Pending\" or \"Running\"")
 				}
 				return false, nil // pod is still pending
@@ -129,8 +129,8 @@ func testCreatingAPodInCluster(cs *kubernetes.Clientset, f *framework.Framework)
 	By("Collecting pod ClusterIPs just for fun")
 	pods, err := pc.List(context.TODO(), metav1.ListOptions{LabelSelector: "example-pod"})
 	Expect(err).NotTo(HaveOccurred())
-	for _, pod := range pods.Items {
-		framework.Logf("Detected pod with IP: %v", pod.Status.PodIP)
+	for i := range pods.Items {
+		framework.Logf("Detected pod with IP: %v", pods.Items[i].Status.PodIP)
 	}
 }
 

--- a/test/e2e/framework/api_errors.go
+++ b/test/e2e/framework/api_errors.go
@@ -31,7 +31,6 @@ func IsTransientError(err error, opMsg string) bool {
 		errors.IsServiceUnavailable(err) ||
 		errors.IsUnexpectedServerError(err) ||
 		errors.IsTooManyRequests(err) {
-
 		Logf("Transient failure when attempting to %s: %v", opMsg, err)
 		return true
 	}

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -33,9 +33,12 @@ var (
 // test to hook into SynchronizedAfterSuite().
 func AddCleanupAction(fn func()) CleanupActionHandle {
 	p := CleanupActionHandle(new(int))
+
 	cleanupActionsLock.Lock()
 	defer cleanupActionsLock.Unlock()
+
 	cleanupActions[p] = fn
+
 	return p
 }
 
@@ -52,13 +55,16 @@ func RemoveCleanupAction(p CleanupActionHandle) {
 // may remove themselves.
 func RunCleanupActions() {
 	list := []func(){}
+
 	func() {
 		cleanupActionsLock.Lock()
 		defer cleanupActionsLock.Unlock()
+
 		for _, fn := range cleanupActions {
 			list = append(list, fn)
 		}
 	}()
+
 	// Run unlocked.
 	for _, fn := range list {
 		fn()

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -20,7 +20,7 @@ package framework
 
 import "sync"
 
-// CleanupActionHandle is an integer pointer type for handling cleanup action
+// CleanupActionHandle is an integer pointer type for handling cleanup action.
 type CleanupActionHandle *int
 
 var (

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -23,8 +23,10 @@ import "sync"
 // CleanupActionHandle is an integer pointer type for handling cleanup action
 type CleanupActionHandle *int
 
-var cleanupActionsLock sync.Mutex
-var cleanupActions = map[CleanupActionHandle]func(){}
+var (
+	cleanupActionsLock sync.Mutex
+	cleanupActions     = map[CleanupActionHandle]func(){}
+)
 
 // AddCleanupAction installs a function that will be called in the event of the
 // whole test being terminated.  This allows arbitrary pieces of the overall

--- a/test/e2e/framework/clusterglobalegressip.go
+++ b/test/e2e/framework/clusterglobalegressip.go
@@ -47,7 +47,7 @@ func AwaitAllocatedEgressIPs(client dynamic.ResourceInterface, name string) []st
 		func() (interface{}, error) {
 			resGip, err := client.Get(context.TODO(), name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
-				return nil, nil
+				return nil, nil // nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 			}
 			return resGip, err
 		},

--- a/test/e2e/framework/clusterglobalegressip.go
+++ b/test/e2e/framework/clusterglobalegressip.go
@@ -75,5 +75,6 @@ func getGlobalIPs(obj *unstructured.Unstructured) []string {
 		globalIPs, _, _ := unstructured.NestedStringSlice(obj.Object, "status", "allocatedIPs")
 		return globalIPs
 	}
+
 	return []string{}
 }

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (f *Framework) FindDeployment(cluster ClusterIndex, appName string, namespace string) *appsv1.Deployment {
+func (f *Framework) FindDeployment(cluster ClusterIndex, appName, namespace string) *appsv1.Deployment {
 	deployments := AwaitUntil("list deployments", func() (interface{}, error) {
 		return KubeClients[cluster].AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{
 			LabelSelector: "app=" + appName,

--- a/test/e2e/framework/docker.go
+++ b/test/e2e/framework/docker.go
@@ -38,7 +38,8 @@ func New(name string) *Docker {
 func (d *Docker) GetIP(networkName string) string {
 	var stdout bytes.Buffer
 
-	cmdargs := []string{"inspect", d.Name, "-f",
+	cmdargs := []string{
+		"inspect", d.Name, "-f",
 		fmt.Sprintf("{{(index .NetworkSettings.Networks \"%s\").IPAddress}}", networkName),
 	}
 	cmd := exec.Command("docker", cmdargs...)

--- a/test/e2e/framework/docker.go
+++ b/test/e2e/framework/docker.go
@@ -55,6 +55,7 @@ func (d *Docker) GetLog() (string, string) {
 	var stdout, stderr bytes.Buffer
 
 	// get stdout and stderr of `docker log {d.Name}` command
+	// #nosec G204 -- the caller-controlled value is only used as the logs argument
 	cmd := exec.Command("docker", "logs", d.Name)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/test/e2e/framework/docker.go
+++ b/test/e2e/framework/docker.go
@@ -40,7 +40,7 @@ func (d *Docker) GetIP(networkName string) string {
 
 	cmdargs := []string{
 		"inspect", d.Name, "-f",
-		fmt.Sprintf("{{(index .NetworkSettings.Networks \"%s\").IPAddress}}", networkName),
+		fmt.Sprintf("{{(index .NetworkSettings.Networks %q).IPAddress}}", networkName),
 	}
 	cmd := exec.Command("docker", cmdargs...)
 	cmd.Stdout = &stdout

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-// ExecOptions passed to ExecWithOptions
+// ExecOptions passed to ExecWithOptions.
 type ExecOptions struct {
 	Command []string
 

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -72,12 +72,13 @@ func (f *Framework) ExecWithOptions(options *ExecOptions, index ClusterIndex) (s
 	}, scheme.ParameterCodec)
 
 	var stdout, stderr bytes.Buffer
-	attempts := 5
-	for ; attempts > 0; attempts-- {
+
+	for attempts := 5; attempts > 0; attempts-- {
 		err = execute("POST", req.URL(), RestConfigs[index], options.Stdin, &stdout, &stderr, tty)
 		if err == nil {
 			break
 		}
+
 		time.Sleep(time.Millisecond * 5000)
 		Logf("Retrying due to error  %+v", err)
 	}
@@ -94,6 +95,7 @@ func execute(method string, reqURL *url.URL, config *restclient.Config, stdin io
 	if err != nil {
 		return err
 	}
+
 	return exec.Stream(remotecommand.StreamOptions{
 		Stdin:  stdin,
 		Stdout: stdout,

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -49,7 +49,7 @@ type ExecOptions struct {
 // ExecWithOptions executes a command in the specified container,
 // returning stdout, stderr and error. `options` allowed for
 // additional parameters to be passed.
-func (f *Framework) ExecWithOptions(options ExecOptions, index ClusterIndex) (string, string, error) {
+func (f *Framework) ExecWithOptions(options *ExecOptions, index ClusterIndex) (string, string, error) {
 	Logf("ExecWithOptions %+v", options)
 
 	var err error
@@ -89,8 +89,8 @@ func (f *Framework) ExecWithOptions(options ExecOptions, index ClusterIndex) (st
 	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
 }
 
-func execute(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
-	exec, err := remotecommand.NewSPDYExecutor(config, method, url)
+func execute(method string, reqURL *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
+	exec, err := remotecommand.NewSPDYExecutor(config, method, reqURL)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -112,11 +112,10 @@ var (
 
 // NewBareFramework creates a test framework, without ginkgo dependencies.
 func NewBareFramework(baseName string) *Framework {
-	f := &Framework{
+	return &Framework{
 		BaseName:           baseName,
 		namespacesToDelete: map[string]bool{},
 	}
-	return f
 }
 
 func AddBeforeSuite(beforeSuite func()) {
@@ -159,6 +158,7 @@ func BeforeSuite() {
 	if len(TestContext.KubeConfig) > 0 {
 		Expect(len(TestContext.KubeConfigs)).To(BeZero(),
 			"Either KubeConfig or KubeConfigs must be specified but not both")
+
 		for _, ctx := range TestContext.KubeContexts {
 			RestConfigs = append(RestConfigs, createRestConfig(TestContext.KubeConfig, ctx))
 		}
@@ -167,7 +167,6 @@ func BeforeSuite() {
 		if len(TestContext.ClusterIDs) == 0 {
 			TestContext.ClusterIDs = TestContext.KubeContexts
 		}
-
 	} else if len(TestContext.KubeConfigs) > 0 {
 		Expect(len(TestContext.KubeConfigs)).To(Equal(len(TestContext.ClusterIDs)),
 			"One ClusterID must be provided for each item in the KubeConfigs")
@@ -265,6 +264,7 @@ func DetectGlobalnet() {
 
 func InitNumClusterNodes() error {
 	TestContext.NumNodesInCluster = map[ClusterIndex]int{}
+
 	for i := range KubeClients {
 		nodes, err := KubeClients[i].CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
@@ -302,6 +302,7 @@ func fetchClusterIDs() {
 
 		const envVarName = "SUBMARINER_CLUSTERID"
 		found := false
+
 		for _, envVar := range daemonSet.Spec.Template.Spec.Containers[0].Env {
 			if envVar.Name == envVarName {
 				if TestContext.ClusterIDs[i] != envVar.Value {
@@ -310,6 +311,7 @@ func fetchClusterIDs() {
 				}
 
 				found = true
+
 				break
 			}
 		}
@@ -328,9 +330,11 @@ func createKubernetesClient(restConfig *rest.Config) *kubeclientset.Clientset {
 	if restConfig.GroupVersion == nil {
 		restConfig.GroupVersion = &schema.GroupVersion{}
 	}
+
 	if restConfig.NegotiatedSerializer == nil {
 		restConfig.NegotiatedSerializer = scheme.Codecs
 	}
+
 	return clientSet
 }
 
@@ -355,9 +359,11 @@ func createRestConfig(kubeConfig, kubeContext string) *rest.Config {
 
 	restConfig.QPS = TestContext.ClientQPS
 	restConfig.Burst = TestContext.ClientBurst
+
 	if TestContext.GroupVersion != nil {
 		restConfig.GroupVersion = TestContext.GroupVersion
 	}
+
 	return restConfig
 }
 
@@ -393,8 +399,10 @@ func (f *Framework) AfterEach() {
 
 func (f *Framework) deleteNamespaceFromAllClusters(ns string) error {
 	var errs []error
+
 	for i, clientSet := range KubeClients {
 		By(fmt.Sprintf("Deleting namespace %q on cluster %q", ns, TestContext.ClusterIDs[i]))
+
 		if err := deleteNamespace(clientSet, ns); err != nil {
 			switch {
 			case apierrors.IsNotFound(err):
@@ -413,9 +421,9 @@ func (f *Framework) deleteNamespaceFromAllClusters(ns string) error {
 // CreateNamespace creates a namespace for e2e testing.
 func (f *Framework) CreateNamespace(clientSet *kubeclientset.Clientset,
 	baseName string, labels map[string]string) *corev1.Namespace {
-
 	ns := createTestNamespace(clientSet, baseName, labels)
 	f.AddNamespacesToDelete(ns)
+
 	return ns
 }
 
@@ -439,6 +447,7 @@ func generateNamespace(client kubeclientset.Interface, baseName string, labels m
 
 	namespace, err := client.CoreV1().Namespaces().Create(context.TODO(), namespaceObj, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Error generating namespace %v", namespaceObj)
+
 	return namespace
 }
 
@@ -457,6 +466,7 @@ func createNamespace(client kubeclientset.Interface, name string, labels map[str
 
 	namespace, err := client.CoreV1().Namespaces().Create(context.TODO(), namespaceObj, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Error creating namespace %v", namespaceObj)
+
 	return namespace
 }
 
@@ -500,6 +510,7 @@ func NoopCheckResult(interface{}) (bool, string, error) {
 func AwaitUntil(opMsg string, doOperation DoOperationFunc, checkResult CheckResultFunc) interface{} {
 	result, errMsg, err := AwaitResultOrError(opMsg, doOperation, checkResult)
 	Expect(err).NotTo(HaveOccurred(), errMsg)
+
 	return result
 }
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -234,7 +234,7 @@ func DetectGlobalnet() {
 	AwaitUntil("find Clusters to detect if Globalnet is enabled", func() (interface{}, error) {
 		clusters, err := clusters.List(context.TODO(), metav1.ListOptions{})
 		if apierrors.IsNotFound(err) {
-			return nil, nil
+			return nil, nil // nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 		}
 		return clusters, err
 	}, func(result interface{}) (bool, string, error) {
@@ -288,7 +288,7 @@ func fetchClusterIDs() {
 		daemonSet := AwaitUntil(fmt.Sprintf("find %s DaemonSet for %q", name, TestContext.ClusterIDs[i]), func() (interface{}, error) {
 			ds, err := KubeClients[i].AppsV1().DaemonSets(TestContext.SubmarinerNamespace).Get(context.TODO(), name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
-				return nil, nil
+				return nil, nil // nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 			}
 
 			return ds, err

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	// Polling interval while trying to create objects
+	// Polling interval while trying to create objects.
 	PollInterval = 100 * time.Millisecond
 )
 
@@ -110,7 +110,7 @@ var (
 	DynClients  []dynamic.Interface
 )
 
-// NewBareFramework creates a test framework, without ginkgo dependencies
+// NewBareFramework creates a test framework, without ginkgo dependencies.
 func NewBareFramework(baseName string) *Framework {
 	f := &Framework{
 		BaseName:           baseName,

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -205,14 +205,15 @@ func (f *Framework) BeforeEach() {
 		}
 
 		for idx, clientSet := range KubeClients {
-			switch ClusterIndex(idx) {
-			case ClusterA: // On the first cluster we let k8s generate a name for the namespace
+			if ClusterIndex(idx) == ClusterA {
+				// On the first cluster we let k8s generate a name for the namespace
 				namespace := generateNamespace(clientSet, f.BaseName, namespaceLabels)
 				f.Namespace = namespace.GetName()
 				f.UniqueName = namespace.GetName()
 				f.AddNamespacesToDelete(namespace)
 				By(fmt.Sprintf("Generated namespace %q in cluster %q to execute the tests in", f.Namespace, TestContext.ClusterIDs[idx]))
-			default: // On the other clusters we use the same name to make tracing easier
+			} else {
+				// On the other clusters we use the same name to make tracing easier
 				By(fmt.Sprintf("Creating namespace %q in cluster %q", f.Namespace, TestContext.ClusterIDs[idx]))
 				f.CreateNamespace(clientSet, f.Namespace, namespaceLabels)
 			}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -417,14 +416,14 @@ func (f *Framework) deleteNamespaceFromAllClusters(ns string) error {
 
 // CreateNamespace creates a namespace for e2e testing.
 func (f *Framework) CreateNamespace(clientSet *kubeclientset.Clientset,
-	baseName string, labels map[string]string) *v1.Namespace {
+	baseName string, labels map[string]string) *corev1.Namespace {
 
 	ns := createTestNamespace(clientSet, baseName, labels)
 	f.AddNamespacesToDelete(ns)
 	return ns
 }
 
-func (f *Framework) AddNamespacesToDelete(namespaces ...*v1.Namespace) {
+func (f *Framework) AddNamespacesToDelete(namespaces ...*corev1.Namespace) {
 	for _, ns := range namespaces {
 		if ns == nil {
 			continue
@@ -434,7 +433,7 @@ func (f *Framework) AddNamespacesToDelete(namespaces ...*v1.Namespace) {
 	}
 }
 
-func generateNamespace(client kubeclientset.Interface, baseName string, labels map[string]string) *v1.Namespace {
+func generateNamespace(client kubeclientset.Interface, baseName string, labels map[string]string) *corev1.Namespace {
 	namespaceObj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("e2e-tests-%v-", baseName),
@@ -447,12 +446,12 @@ func generateNamespace(client kubeclientset.Interface, baseName string, labels m
 	return namespace
 }
 
-func createTestNamespace(client kubeclientset.Interface, name string, labels map[string]string) *v1.Namespace {
+func createTestNamespace(client kubeclientset.Interface, name string, labels map[string]string) *corev1.Namespace {
 	namespace := createNamespace(client, name, labels)
 	return namespace
 }
 
-func createNamespace(client kubeclientset.Interface, name string, labels map[string]string) *v1.Namespace {
+func createNamespace(client kubeclientset.Interface, name string, labels map[string]string) *corev1.Namespace {
 	namespaceObj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -78,8 +78,10 @@ type PatchUInt32Value struct {
 	Value uint32 `json:"value"`
 }
 
-type DoOperationFunc func() (interface{}, error)
-type CheckResultFunc func(result interface{}) (bool, string, error)
+type (
+	DoOperationFunc func() (interface{}, error)
+	CheckResultFunc func(result interface{}) (bool, string, error)
+)
 
 // Framework supports common operations used by e2e tests; it will keep a client & a namespace for you.
 // Eventual goal is to merge this with integration test framework.
@@ -122,13 +124,16 @@ func AddBeforeSuite(beforeSuite func()) {
 	beforeSuiteFuncs = append(beforeSuiteFuncs, beforeSuite)
 }
 
-var By func(string)
-var Fail func(string)
-var userAgentFunction func() string
+var (
+	By                func(string)
+	Fail              func(string)
+	userAgentFunction func() string
+)
 
 func SetStatusFunction(by func(string)) {
 	By = by
 }
+
 func SetFailFunction(fail func(string)) {
 	Fail = fail
 }
@@ -217,7 +222,6 @@ func (f *Framework) BeforeEach() {
 	} else {
 		f.UniqueName = string(uuid.NewUUID())
 	}
-
 }
 
 func DetectGlobalnet() {
@@ -332,7 +336,6 @@ func createKubernetesClient(restConfig *rest.Config) *kubeclientset.Clientset {
 }
 
 func createDynamicClient(restConfig *rest.Config) dynamic.Interface {
-
 	clientSet, err := dynamic.NewForConfig(restConfig)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -391,7 +394,6 @@ func (f *Framework) AfterEach() {
 			Failf(k8serrors.NewAggregate(nsDeletionErrors).Error())
 		}
 	}()
-
 }
 
 func (f *Framework) deleteNamespaceFromAllClusters(ns string) error {

--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -55,7 +55,7 @@ func (f *Framework) AwaitGatewayWithStatus(cluster ClusterIndex, name, status st
 			gw := result.(*unstructured.Unstructured)
 			haStatus := NestedString(gw.Object, "status", "haStatus")
 			if haStatus != status {
-				return false, "", fmt.Errorf("Gateway %q exists but has wrong status %q, expected %q",
+				return false, "", fmt.Errorf("gateway %q exists but has wrong status %q, expected %q",
 					gw.GetName(), haStatus, status)
 			}
 			return true, "", nil

--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -87,6 +87,7 @@ func (f *Framework) AwaitGatewaysWithStatus(cluster ClusterIndex, status string)
 
 func (f *Framework) AwaitGatewayRemoved(cluster ClusterIndex, name string) {
 	gwClient := gatewayClient(cluster)
+
 	AwaitUntil(fmt.Sprintf("await Gateway on %q removed", name),
 		func() (interface{}, error) {
 			_, err := gwClient.Get(context.TODO(), name, metav1.GetOptions{})

--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -43,7 +43,7 @@ func (f *Framework) AwaitGatewayWithStatus(cluster ClusterIndex, name, status st
 		func() (interface{}, error) {
 			resGw, err := gwClient.Get(context.TODO(), name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
-				return nil, nil
+				return nil, nil // nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 			}
 			return resGw, err
 		},
@@ -108,7 +108,7 @@ func (f *Framework) AwaitGatewayFullyConnected(cluster ClusterIndex, name string
 		func() (interface{}, error) {
 			resGw, err := gwClient.Get(context.TODO(), name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
-				return nil, nil
+				return nil, nil // nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 			}
 			return resGw, err
 		},
@@ -172,7 +172,7 @@ func (f *Framework) DeleteGateway(cluster ClusterIndex, name string) {
 	AwaitUntil("delete gateway", func() (interface{}, error) {
 		err := gatewayClient(cluster).Delete(context.TODO(), name, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
-			return nil, nil
+			return nil, nil // nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 		}
 		return nil, err
 	}, NoopCheckResult)

--- a/test/e2e/framework/ginkgo_framework.go
+++ b/test/e2e/framework/ginkgo_framework.go
@@ -20,7 +20,7 @@ package framework
 
 import "github.com/onsi/ginkgo"
 
-// NewFramework creates a test framework, under ginkgo
+// NewFramework creates a test framework, under ginkgo.
 func NewFramework(baseName string) *Framework {
 	f := NewBareFramework(baseName)
 

--- a/test/e2e/framework/ginkgowrapper/wrapper.go
+++ b/test/e2e/framework/ginkgowrapper/wrapper.go
@@ -106,7 +106,7 @@ func Skip(message string, callerSkip ...int) {
 }
 
 // ginkgo adds a lot of test running infrastructure to the stack, so
-// we filter those out
+// we filter those out.
 var stackSkipPattern = regexp.MustCompile(`onsi/ginkgo`)
 
 func pruneStack(skip int) string {

--- a/test/e2e/framework/globalegressip.go
+++ b/test/e2e/framework/globalegressip.go
@@ -40,6 +40,7 @@ func globalEgressIPClient(cluster ClusterIndex, namespace string) dynamic.Resour
 
 func CreateGlobalEgressIP(cluster ClusterIndex, obj *unstructured.Unstructured) error {
 	geipClient := globalEgressIPClient(cluster, obj.GetNamespace())
+
 	AwaitUntil("create GlobalEgressIP", func() (interface{}, error) {
 		egressIP, err := geipClient.Create(context.TODO(), obj, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {

--- a/test/e2e/framework/globalingressips.go
+++ b/test/e2e/framework/globalingressips.go
@@ -42,7 +42,7 @@ func (f *Framework) AwaitGlobalIngressIP(cluster ClusterIndex, name, namespace s
 			func() (interface{}, error) {
 				resGip, err := gipClient.Get(context.TODO(), name, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
-					return nil, nil
+					return nil, nil // nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 				}
 				return resGip, err
 			},

--- a/test/e2e/framework/globalingressips.go
+++ b/test/e2e/framework/globalingressips.go
@@ -61,6 +61,7 @@ func (f *Framework) AwaitGlobalIngressIP(cluster ClusterIndex, name, namespace s
 
 		return getGlobalIP(obj.(*unstructured.Unstructured))
 	}
+
 	return ""
 }
 
@@ -89,5 +90,6 @@ func getGlobalIP(obj *unstructured.Unstructured) string {
 		globalIP, _, _ := unstructured.NestedString(obj.Object, "status", "allocatedIP")
 		return globalIP
 	}
+
 	return ""
 }

--- a/test/e2e/framework/logging.go
+++ b/test/e2e/framework/logging.go
@@ -30,7 +30,7 @@ func nowStamp() string {
 	return time.Now().Format(time.StampMilli)
 }
 
-func log(level string, format string, args ...interface{}) {
+func log(level, format string, args ...interface{}) {
 	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
 }
 

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -94,7 +94,6 @@ const (
 )
 
 func (f *Framework) NewNetworkPod(config *NetworkPodConfig) *NetworkPod {
-
 	// check if all necessary details are provided
 	Expect(config.Scheduling).ShouldNot(Equal(InvalidScheduling))
 	Expect(config.Type).ShouldNot(Equal(InvalidPodType))
@@ -243,7 +242,6 @@ func (np *NetworkPod) GetLog() string {
 // The pod will listen on TestPort over TCP, send sendString over the connection,
 // and write the network response in the pod  termination log, then exit with 0 status
 func (np *NetworkPod) buildTCPCheckListenerPod() {
-
 	tcpCheckListenerPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "tcp-check-listener",
@@ -284,7 +282,6 @@ func (np *NetworkPod) buildTCPCheckListenerPod() {
 // connection, and write the network response in the pod termination log, then
 // exit with 0 status
 func (np *NetworkPod) buildTCPCheckConnectorPod() {
-
 	tcpCheckConnectorPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "tcp-check-pod",
@@ -418,7 +415,8 @@ func (np *NetworkPod) buildLatencyClientPod() {
 					Image:           "quay.io/submariner/nettest:devel",
 					ImagePullPolicy: v1.PullAlways,
 					Command: []string{
-						"sh", "-c", "netperf -H $TARGET_IP -t TCP_RR  -- -o min_latency,mean_latency,max_latency,stddev_latency,transaction_rate >/dev/termination-log 2>&1"},
+						"sh", "-c", "netperf -H $TARGET_IP -t TCP_RR  -- -o min_latency,mean_latency,max_latency,stddev_latency,transaction_rate >/dev/termination-log 2>&1",
+					},
 					Env: []v1.EnvVar{
 						{Name: "TARGET_IP", Value: np.Config.RemoteIP},
 					},

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -188,7 +188,7 @@ func (np *NetworkPod) CreateService() *v1.Service {
 	return np.framework.CreateTCPService(np.Config.Cluster, np.Pod.Labels[TestAppLabel], np.Config.Port)
 }
 
-// RunCommand run the specified command in this NetworkPod
+// RunCommand run the specified command in this NetworkPod.
 func (np *NetworkPod) RunCommand(cmd []string) (string, string) {
 	req := KubeClients[np.Config.Cluster].CoreV1().RESTClient().Post().
 		Resource("pods").Name(np.Pod.Name).Namespace(np.Pod.Namespace).
@@ -221,7 +221,7 @@ func (np *NetworkPod) RunCommand(cmd []string) (string, string) {
 	return stdout.String(), stderr.String()
 }
 
-// GetLog returns container log from this NetworkPod
+// GetLog returns container log from this NetworkPod.
 func (np *NetworkPod) GetLog() string {
 	req := KubeClients[np.Config.Cluster].CoreV1().Pods(np.Pod.Namespace).GetLogs(np.Pod.Name, &v1.PodLogOptions{})
 
@@ -239,7 +239,7 @@ func (np *NetworkPod) GetLog() string {
 
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will listen on TestPort over TCP, send sendString over the connection,
-// and write the network response in the pod  termination log, then exit with 0 status
+// and write the network response in the pod  termination log, then exit with 0 status.
 func (np *NetworkPod) buildTCPCheckListenerPod() {
 	tcpCheckListenerPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -279,7 +279,7 @@ func (np *NetworkPod) buildTCPCheckListenerPod() {
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will connect to remoteIP:TestPort over TCP, send sendString over the
 // connection, and write the network response in the pod termination log, then
-// exit with 0 status
+// exit with 0 status.
 func (np *NetworkPod) buildTCPCheckConnectorPod() {
 	tcpCheckConnectorPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -322,7 +322,7 @@ func (np *NetworkPod) buildTCPCheckConnectorPod() {
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will initiate iperf3 throughput test to remoteIP and write the test
 // response in the pod termination log, then
-// exit with 0 status
+// exit with 0 status.
 func (np *NetworkPod) buildThroughputClientPod() {
 	nettestPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -360,7 +360,7 @@ func (np *NetworkPod) buildThroughputClientPod() {
 }
 
 // create a test pod inside the current test namespace on the specified cluster.
-// The pod will start iperf3 in server mode
+// The pod will start iperf3 in server mode.
 func (np *NetworkPod) buildThroughputServerPod() {
 	nettestPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -396,7 +396,7 @@ func (np *NetworkPod) buildThroughputServerPod() {
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will initiate netperf latency test to remoteIP and write the test
 // response in the pod termination log, then
-// exit with 0 status
+// exit with 0 status.
 func (np *NetworkPod) buildLatencyClientPod() {
 	nettestPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -432,7 +432,7 @@ func (np *NetworkPod) buildLatencyClientPod() {
 }
 
 // create a test pod inside the current test namespace on the specified cluster.
-// The pod will start netserver (server of netperf)
+// The pod will start netserver (server of netperf).
 func (np *NetworkPod) buildLatencyServerPod() {
 	nettestPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -228,6 +228,7 @@ func (np *NetworkPod) GetLog() string {
 
 	closer, err := req.Stream(context.TODO())
 	Expect(err).NotTo(HaveOccurred())
+
 	defer closer.Close()
 
 	out := new(strings.Builder)
@@ -561,6 +562,7 @@ func addNodeSelectorTerm(nodeSelTerms []v1.NodeSelectorTerm, label string,
 func removeDupDataplaneLines(output string) string {
 	var newLines []string
 	var lastLine string
+
 	for _, line := range strings.Split(output, "\n") {
 		if !strings.HasPrefix(line, "[dataplane]") || line != lastLine {
 			newLines = append(newLines, line)

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -26,13 +26,12 @@ import (
 	"strconv"
 	"strings"
 
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
-
-	. "github.com/onsi/gomega"
 )
 
 type NetworkingType bool

--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -61,7 +61,7 @@ func findNodesByGatewayLabel(cluster int, isGateway bool) []*v1.Node {
 // SetGatewayLabelOnNode sets the 'submariner.io/gateway' value for a node to the specified value.
 func (f *Framework) SetGatewayLabelOnNode(cluster ClusterIndex, nodeName string, isGateway bool) {
 	// Escape the '/' char in the label name with the special sequence "~1" so it isn't treated as part of the path
-	PatchString("/metadata/labels/"+strings.Replace(GatewayLabel, "/", "~1", -1), strconv.FormatBool(isGateway),
+	PatchString("/metadata/labels/"+strings.ReplaceAll(GatewayLabel, "/", "~1"), strconv.FormatBool(isGateway),
 		func(pt types.PatchType, payload []byte) error {
 			_, err := KubeClients[cluster].CoreV1().Nodes().Patch(context.TODO(), nodeName, pt, payload, metav1.PatchOptions{})
 			return err

--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -44,6 +44,7 @@ func findNodesByGatewayLabel(cluster int, isGateway bool) []*v1.Node {
 
 	expLabelValue := strconv.FormatBool(isGateway)
 	retNodes := []*v1.Node{}
+
 	for i := range nodes.Items {
 		value, exists := nodes.Items[i].Labels[GatewayLabel]
 		if !exists {

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -54,7 +54,7 @@ func (f *Framework) AwaitPodsByLabelSelector(cluster ClusterIndex, labelSelector
 // AwaitPodsByAppLabel finds pods in a given cluster whose 'app' label value matches a specified value. If the specified
 // expectedCount >= 0, the function waits until the number of pods equals the expectedCount.
 func (f *Framework) AwaitPodsByAppLabel(cluster ClusterIndex, appName string, namespace string, expectedCount int) *v1.PodList {
-	return f.AwaitPodsByLabelSelector(cluster, "app=" + appName, namespace, expectedCount)
+	return f.AwaitPodsByLabelSelector(cluster, "app="+appName, namespace, expectedCount)
 }
 
 // AwaitSubmarinerGatewayPod finds the submariner gateway pod in a given cluster, waiting if necessary for a period of time
@@ -96,8 +96,7 @@ func (f *Framework) AwaitUntilAnnotationOnPod(cluster ClusterIndex, annotation s
 func (f *Framework) AwaitRouteAgentPodOnNode(cluster ClusterIndex, nodeName string, prevPodUID types.UID) *v1.Pod {
 	var found *v1.Pod
 
-	AwaitUntil(fmt.Sprintf("find route agent pod on node %q", nodeName), func() (interface {
-	}, error) {
+	AwaitUntil(fmt.Sprintf("find route agent pod on node %q", nodeName), func() (interface{}, error) {
 		return KubeClients[cluster].CoreV1().Pods(TestContext.SubmarinerNamespace).List(context.TODO(), metav1.ListOptions{
 			LabelSelector: "app=" + RouteAgent,
 		})

--- a/test/e2e/framework/service_exports.go
+++ b/test/e2e/framework/service_exports.go
@@ -27,13 +27,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var (
-	gvr = schema.GroupVersionResource{
-		Group:    "multicluster.x-k8s.io",
-		Version:  "v1alpha1",
-		Resource: "serviceexports",
-	}
-)
+var gvr = schema.GroupVersionResource{
+	Group:    "multicluster.x-k8s.io",
+	Version:  "v1alpha1",
+	Resource: "serviceexports",
+}
 
 func (f *Framework) CreateServiceExport(cluster ClusterIndex, name string) {
 	resourceServiceExport := &unstructured.Unstructured{}

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -151,7 +151,7 @@ func (f *Framework) DeleteService(cluster ClusterIndex, serviceName string) {
 }
 
 // AwaitUntilAnnotationOnService queries the service and looks for the presence of annotation.
-func (f *Framework) AwaitUntilAnnotationOnService(cluster ClusterIndex, annotation string, svcName string, namespace string) *corev1.Service {
+func (f *Framework) AwaitUntilAnnotationOnService(cluster ClusterIndex, annotation, svcName, namespace string) *corev1.Service {
 	return AwaitUntil("get"+annotation+" annotation for service "+svcName, func() (interface{}, error) {
 		service, err := KubeClients[cluster].CoreV1().Services(namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -35,7 +35,7 @@ const (
 )
 
 func (f *Framework) NewService(name, portName string, port int, protocol corev1.Protocol, selector map[string]string,
-		isHeadless bool) *corev1.Service {
+	isHeadless bool) *corev1.Service {
 	service := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -64,7 +64,7 @@ func (f *Framework) NewService(name, portName string, port int, protocol corev1.
 
 func (f *Framework) CreateTCPService(cluster ClusterIndex, selectorName string, port int) *corev1.Service {
 	tcpService := f.NewService(fmt.Sprintf("test-svc-%s", selectorName), "tcp", port, corev1.ProtocolTCP,
-		map[string]string{TestAppLabel:selectorName}, false)
+		map[string]string{TestAppLabel: selectorName}, false)
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
 	return f.CreateService(sc, tcpService)
@@ -72,7 +72,7 @@ func (f *Framework) CreateTCPService(cluster ClusterIndex, selectorName string, 
 
 func (f *Framework) CreateHeadlessTCPService(cluster ClusterIndex, selectorName string, port int) *corev1.Service {
 	tcpService := f.NewService(fmt.Sprintf("test-svc-%s", selectorName), "tcp", port, corev1.ProtocolTCP,
-		map[string]string{TestAppLabel:selectorName}, true)
+		map[string]string{TestAppLabel: selectorName}, true)
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
 	return f.CreateService(sc, tcpService)

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -131,7 +130,7 @@ func (f *Framework) CreateTCPServiceWithoutSelector(cluster ClusterIndex, svcNam
 func (f *Framework) CreateService(sc typedv1.ServiceInterface, serviceSpec *corev1.Service) *corev1.Service {
 	return AwaitUntil("create service", func() (interface{}, error) {
 		service, err := sc.Create(context.TODO(), serviceSpec, metav1.CreateOptions{})
-		if errors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			err = sc.Delete(context.TODO(), serviceSpec.Name, metav1.DeleteOptions{})
 			if err != nil {
 				return nil, err

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -56,7 +56,7 @@ func (contexts *contextArray) Set(value string) error {
 	return nil
 }
 
-var TestContext *TestContextType = &TestContextType{
+var TestContext = &TestContextType{
 	ClientQPS:   20,
 	ClientBurst: 50,
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -75,7 +75,7 @@ func init() {
 }
 
 func ValidateFlags(t *TestContextType) {
-	if len(t.KubeConfig) == 0 && len(t.KubeConfigs) == 0 {
+	if t.KubeConfig == "" && len(t.KubeConfigs) == 0 {
 		klog.Fatalf("kubeconfig parameter or KUBECONFIG environment variable is required")
 	}
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -65,11 +65,16 @@ func init() {
 	flag.StringVar(&TestContext.KubeConfig, "kubeconfig", os.Getenv("KUBECONFIG"),
 		"Path to kubeconfig containing embedded authinfo.")
 	flag.Var(&TestContext.KubeContexts, "dp-context", "kubeconfig context for dataplane clusters (use several times).")
-	flag.StringVar(&TestContext.ReportPrefix, "report-prefix", "", "Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
-	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
-	flag.StringVar(&TestContext.SubmarinerNamespace, "submariner-namespace", "submariner", "Namespace in which the submariner components are deployed.")
-	flag.UintVar(&TestContext.ConnectionTimeout, "connection-timeout", 18, "The timeout in seconds per connection attempt when verifying communication between clusters.")
-	flag.UintVar(&TestContext.ConnectionAttempts, "connection-attempts", 7, "The number of connection attempts when verifying communication between clusters.")
+	flag.StringVar(&TestContext.ReportPrefix, "report-prefix", "",
+		"Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
+	flag.StringVar(&TestContext.ReportDir, "report-dir", "",
+		"Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
+	flag.StringVar(&TestContext.SubmarinerNamespace, "submariner-namespace", "submariner",
+		"Namespace in which the submariner components are deployed.")
+	flag.UintVar(&TestContext.ConnectionTimeout, "connection-timeout", 18,
+		"The timeout in seconds per connection attempt when verifying communication between clusters.")
+	flag.UintVar(&TestContext.ConnectionAttempts, "connection-attempts", 7,
+		"The number of connection attempts when verifying communication between clusters.")
 	flag.UintVar(&TestContext.OperationTimeout, "operation-timeout", 190, "The general operation timeout in seconds.")
 	flag.BoolVar(&TestContext.GlobalnetEnabled, "globalnet", false, "Indicates if the globalnet feature is enabled.")
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 
 	. "github.com/onsi/gomega"
+
+	// We need GCP authentication.
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -35,9 +35,11 @@ func loadConfig(configPath, context string) (*restclient.Config, error) {
 
 	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
+
 	if context != "" {
 		overrides.CurrentContext = context
 	}
+
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).ClientConfig()
 }
 
@@ -51,5 +53,6 @@ func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
 	if err != nil {
 		Logf("Unexpected error occurred: %v", err)
 	}
+
 	ExpectWithOffset(1+offset, err).NotTo(HaveOccurred(), explain...)
 }

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -121,7 +121,6 @@ func RunNoConnectivityTest(p ConnectivityTestParams) (*framework.NetworkPod, *fr
 }
 
 func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.NetworkPod) {
-
 	By(fmt.Sprintf("Creating a listener pod in cluster %q, which will wait for a handshake over TCP", framework.TestContext.ClusterIDs[p.ToCluster]))
 	listenerPod := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
 		Type:               framework.ListenerPod,

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -121,7 +121,8 @@ func RunNoConnectivityTest(p ConnectivityTestParams) (*framework.NetworkPod, *fr
 }
 
 func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.NetworkPod) {
-	By(fmt.Sprintf("Creating a listener pod in cluster %q, which will wait for a handshake over TCP", framework.TestContext.ClusterIDs[p.ToCluster]))
+	By(fmt.Sprintf("Creating a listener pod in cluster %q, which will wait for a handshake over TCP",
+		framework.TestContext.ClusterIDs[p.ToCluster]))
 	listenerPod := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
 		Type:               framework.ListenerPod,
 		Cluster:            p.ToCluster,
@@ -133,7 +134,8 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 	remoteIP := listenerPod.Pod.Status.PodIP
 	var service *v1.Service
 	if p.ToEndpointType == ServiceIP || p.ToEndpointType == GlobalServiceIP {
-		By(fmt.Sprintf("Pointing a service ClusterIP to the listener pod in cluster %q", framework.TestContext.ClusterIDs[p.ToCluster]))
+		By(fmt.Sprintf("Pointing a service ClusterIP to the listener pod in cluster %q",
+			framework.TestContext.ClusterIDs[p.ToCluster]))
 		service = listenerPod.CreateService()
 		remoteIP = service.Spec.ClusterIP
 
@@ -147,7 +149,8 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 
 	framework.Logf("Will send traffic to IP: %v", remoteIP)
 
-	By(fmt.Sprintf("Creating a connector pod in cluster %q, which will attempt the specific UUID handshake over TCP", framework.TestContext.ClusterIDs[p.FromCluster]))
+	By(fmt.Sprintf("Creating a connector pod in cluster %q, which will attempt the specific UUID handshake over TCP",
+		framework.TestContext.ClusterIDs[p.FromCluster]))
 	connectorPod := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
 		Type:               framework.ConnectorPod,
 		Cluster:            p.FromCluster,
@@ -160,7 +163,8 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 
 	if p.ToEndpointType == GlobalServiceIP && p.Networking == framework.PodNetworking {
 		// Wait for the globalIP annotation on the connectorPod.
-		connectorPod.Pod = p.Framework.AwaitUntilAnnotationOnPod(p.FromCluster, globalnetGlobalIPAnnotation, connectorPod.Pod.Name, connectorPod.Pod.Namespace)
+		connectorPod.Pod = p.Framework.AwaitUntilAnnotationOnPod(p.FromCluster, globalnetGlobalIPAnnotation, connectorPod.Pod.Name,
+			connectorPod.Pod.Namespace)
 		sourceIP := connectorPod.Pod.GetAnnotations()[globalnetGlobalIPAnnotation]
 		framework.Logf("Will send traffic from IP: %v", sourceIP)
 	}

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -35,7 +35,7 @@ type EndpointType int
 const (
 	PodIP EndpointType = iota
 	ServiceIP
-	// TODO: Remove GlobalIP once all consumer code switches to GlobalServiceIP
+	// TODO: Remove GlobalIP once all consumer code switches to GlobalServiceIP.
 	GlobalIP
 	GlobalPodIP
 	GlobalServiceIP = GlobalIP

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -76,6 +76,7 @@ func RunConnectivityTest(p ConnectivityTestParams) (*framework.NetworkPod, *fram
 			// Globalnet Controller MASQUERADEs the source-ip of the POD to the corresponding global-ip
 			// that is assigned to the POD.
 			By("Verifying the output of listener pod which must contain the globalIP of the connector POD")
+
 			podGlobalIP := connectorPod.Pod.GetAnnotations()[globalnetGlobalIPAnnotation]
 			Expect(podGlobalIP).ToNot(Equal(""))
 			Expect(listenerPod.TerminationMessage).To(ContainSubstring(podGlobalIP))
@@ -123,6 +124,7 @@ func RunNoConnectivityTest(p ConnectivityTestParams) (*framework.NetworkPod, *fr
 func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.NetworkPod) {
 	By(fmt.Sprintf("Creating a listener pod in cluster %q, which will wait for a handshake over TCP",
 		framework.TestContext.ClusterIDs[p.ToCluster]))
+
 	listenerPod := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
 		Type:               framework.ListenerPod,
 		Cluster:            p.ToCluster,
@@ -133,9 +135,11 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 
 	remoteIP := listenerPod.Pod.Status.PodIP
 	var service *v1.Service
+
 	if p.ToEndpointType == ServiceIP || p.ToEndpointType == GlobalServiceIP {
 		By(fmt.Sprintf("Pointing a service ClusterIP to the listener pod in cluster %q",
 			framework.TestContext.ClusterIDs[p.ToCluster]))
+
 		service = listenerPod.CreateService()
 		remoteIP = service.Spec.ClusterIP
 
@@ -151,6 +155,7 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 
 	By(fmt.Sprintf("Creating a connector pod in cluster %q, which will attempt the specific UUID handshake over TCP",
 		framework.TestContext.ClusterIDs[p.FromCluster]))
+
 	connectorPod := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
 		Type:               framework.ConnectorPod,
 		Cluster:            p.FromCluster,


### PR DESCRIPTION
This replaces Docker buildx, inside the Dapper image for now.
Multi-arch builds are supported using manifests.

The default platform is now the runtime platform, rather than
"linux/amd64"; this should make it simpler to build local images for
local consumptions on ARM systems in particular.

The containerd and selinux* packages are no longer installed, so we no
longer need to remove them. Explicitly installing nodejs means we can
also remove npm and python3-pip using dnf.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
